### PR TITLE
ビルド時に外部の画像用リポジトリをクローン・画像用のコンポーネントの切り出し

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,node,react,sublimetext,vim,visualstudiocode,windows
+
+# Resource リソースは別のリポジトリ
+vpn-website-resource
+public

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   "author": "VirtualProgrammersNetwork",
   "repository": "github:VirtualProgrammersNetwork/vpn-website",
   "scripts": {
-    "build": "next build && next export",
+    "build": "npm run rsrc:clone || next build && next start",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint --cache --fix .",
     "lint:stylelint": "stylelint \"**/*.css\"",
     "prepare": "husky install",
     "serve": "serve out",
-    "start": "next dev"
+    "start": "next dev",
+    "rsrc:clone": "git clone https://github.com/VirtualProgrammersNetwork/vpn-website-resource.git && cp vpn-website-resource/public .",
+    "rsrc:pull": "cd vpn-website-resource && git pull && cd ../ && cp -r vpn-website-resource/public ."
   },
   "dependencies": {
     "@emotion/react": "^11.4.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "VirtualProgrammersNetwork",
   "repository": "github:VirtualProgrammersNetwork/vpn-website",
   "scripts": {
-    "build": "npm run rsrc:clone || next build && next start",
+    "build": "npm run rsrc:clone || next build && next export",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint --cache --fix .",
     "lint:stylelint": "stylelint \"**/*.css\"",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
   "author": "VirtualProgrammersNetwork",
   "repository": "github:VirtualProgrammersNetwork/vpn-website",
   "scripts": {
-    "build": "npm run rsrc:clone || next build && next export",
+    "build": "npm run rsrc && next build && next export",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint --cache --fix .",
     "lint:stylelint": "stylelint \"**/*.css\"",
     "prepare": "husky install",
     "serve": "serve out",
-    "start": "next dev",
+    "start": "npm run rsrc && next dev",
+    "rsrc": "npm run rsrc:clone || npm run rsrc:pull",
     "rsrc:clone": "git clone https://github.com/VirtualProgrammersNetwork/vpn-website-resource.git && cp vpn-website-resource/public .",
     "rsrc:pull": "cd vpn-website-resource && git pull && cd ../ && cp -r vpn-website-resource/public ."
   },

--- a/src/blog_posts/test.md
+++ b/src/blog_posts/test.md
@@ -7,6 +7,8 @@ tags: ["test", "hoge", "fuga"]
 
 # これは`テスト`です
 
+![画像1](/author-icons/tamayurasouki.png)
+
 ## ぷげら
 
 つまりこういうことって**わけ**

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable @next/next/no-img-element */
+type Props = {
+  src: string;
+  alt: string;
+  width: string | number | undefined;
+  height: string | number | undefined;
+};
+
+// img elementのラッパー
+// TODO: 画像の最適化等を実装する際に書き換える
+const Img = ({ src, alt, width, height }: Props): JSX.Element => {
+  return (
+    <picture>
+      <img src={src} alt={alt} width={width} height={height} />
+    </picture>
+  );
+};
+
+export default Img;

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 type Props = {
+  // src: /public/hoge/fuga.png -> /hoge/fuga.png と指定
   src: string;
   alt: string;
   width: string | number | undefined;

--- a/src/components/post-header.tsx
+++ b/src/components/post-header.tsx
@@ -1,3 +1,6 @@
+import Image from 'next/image';
+import { join } from 'path';
+// eslint-disable-next-line sort-imports
 import Author from '../types/author';
 
 type Props = {
@@ -12,7 +15,15 @@ const PostHeader = ({ title, author, tags }: Props): JSX.Element => {
     <>
       <h1>{title}</h1>
       <div>{tagIcons}</div>
-      <div>{author.name}</div>
+      <div>
+        <Image
+          src={join('/author-icons', 'tamayurasouki.png')}
+          width={50}
+          height={50}
+          alt="pics"
+        />
+        {author.name}
+      </div>
     </>
   );
 };

--- a/src/components/post-header.tsx
+++ b/src/components/post-header.tsx
@@ -1,7 +1,5 @@
-import Image from 'next/image';
-import { join } from 'path';
-// eslint-disable-next-line sort-imports
 import Author from '../types/author';
+import Img from './image';
 
 type Props = {
   title: string;
@@ -16,11 +14,11 @@ const PostHeader = ({ title, author, tags }: Props): JSX.Element => {
       <h1>{title}</h1>
       <div>{tagIcons}</div>
       <div>
-        <Image
-          src={join('/author-icons', 'tamayurasouki.png')}
+        <Img
+          src="/author-icons/tamayurasouki.png"
+          alt="icon"
           width={50}
           height={50}
-          alt="pics"
         />
         {author.name}
       </div>

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -1,15 +1,32 @@
 import ErrorPage from 'next/error';
 import { NextPage } from 'next';
 import ReactMarkdown from 'react-markdown';
+import { ReactMarkdownProps } from 'react-markdown/lib/complex-types';
 import { useRouter } from 'next/router';
 // eslint-disable-next-line sort-imports
+import { ClassAttributes, ImgHTMLAttributes } from 'react';
 import { getAllPosts, getPostBySlug } from '../../lib/posts-utils';
 import Author from '../../types/author';
+import Img from '../../components/image';
 import PostHeader from '../../components/post-header';
 import PostType from '../../types/post';
 
 type Props = {
   post: PostType;
+};
+
+type ImgProps = ClassAttributes<HTMLImageElement> &
+  ImgHTMLAttributes<HTMLImageElement> &
+  ReactMarkdownProps;
+
+const MarkdownImg: React.FC<ImgProps> = ({
+  src,
+  alt = 'no img',
+  width,
+  height,
+}) => {
+  if (!src) return <></>;
+  return <Img src={src} alt={alt} width={width} height={height} />;
 };
 
 const Post: NextPage<Props> = ({ post }: Props) => {
@@ -22,7 +39,7 @@ const Post: NextPage<Props> = ({ post }: Props) => {
   return (
     <main tw="prose">
       <PostHeader title={post.title} author={post.author} tags={post.tags} />
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown components={{ img: MarkdownImg }}>{content}</ReactMarkdown>
     </main>
   );
 };

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -11,10 +11,7 @@ import Img from '../../components/image';
 import PostHeader from '../../components/post-header';
 import PostType from '../../types/post';
 
-type Props = {
-  post: PostType;
-};
-
+// react markdown用に独自のimgタグを定義
 type ImgProps = ClassAttributes<HTMLImageElement> &
   ImgHTMLAttributes<HTMLImageElement> &
   ReactMarkdownProps;
@@ -27,6 +24,11 @@ const MarkdownImg: React.FC<ImgProps> = ({
 }) => {
   if (!src) return <></>;
   return <Img src={src} alt={alt} width={width} height={height} />;
+};
+
+// マークダウンページ
+type Props = {
+  post: PostType;
 };
 
 const Post: NextPage<Props> = ({ post }: Props) => {


### PR DESCRIPTION
- 画像用のリポジトリを作成した
  - https://github.com/VirtualProgrammersNetwork/vpn-website-resource
  - `npm run rsrc`とすると、リポジトリが`git clone || git pull`され、プロジェクト直下のpublicファイルに画像が配置される。
  - ビルド時に`npm run rsrc`が実行され、外部のリポジトリの画像が含められる
  -  #2 も参照

- 画像用のコンポーネントの切り出し
  - `src/components/image.tsx`に画像用のコンポーネント`Img`を切り出した
  - markdown内の画像についても`Img`を使用するようにした
  - 画像最適化の方法は要検討であるため、差し当たって、ただの`img`タグを使った画像用コンポーネントを切り出した。いつか適切な形で実装する必要がある。
  - #14 も参照