### PR TITLE
fix: GitHub Pagesだと、URLのルートが変わって、パス指定周りがうまくいかない問題

### DIFF
--- a/.github/workflows/push-feature.yml
+++ b/.github/workflows/push-feature.yml
@@ -39,4 +39,5 @@ jobs:
       - run: npm run build
         env:
           CI: true
+          GITHUB_PAGES: true
       - run: npm run lint

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -37,6 +37,7 @@ jobs:
       - run: npm run build
         env:
           CI: true
+          GITHUB_PAGES: true
       - name: ビルド結果を GitHub Pages へ配置します。
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,18 @@
+const localDomain = '';
+const productDomain = 'https://virtualprogrammersnetwork.github.io';
+const productPath = '/vpn-website';
+const isProd = process.env.NODE_ENV === 'production';
+const isCI = !!process.env.CI;
+const path = isCI && isProd ? productPath : '';
+const assetPrefix = (isCI && isProd ? productDomain : localDomain) + path;
+
 /** @type {Partial<import('next/dist/next-server/server/config-shared').NextConfig>} */
-const providedExports = { future: { strictPostcssConfiguration: true } };
+const providedExports = {
+  assetPrefix,
+  basePath: path,
+  env: { assetPrefix },
+  future: { strictPostcssConfiguration: true },
+};
 
 /** @type {Partial<import('next/dist/next-server/server/config-shared').NextConfig>} */
 module.exports = providedExports;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-twin": "^1.0.2",
         "browserslist": "^4.16.6",
+        "dotenv": "^10.0.0",
         "eslint": "^7.30.0",
         "eslint-config-airbnb-typescript": "^12.3.1",
         "eslint-config-next": "^11.0.1",
@@ -3264,6 +3265,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dset": {
@@ -15088,6 +15098,12 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
     },
     "dset": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-twin": "^1.0.2",
     "browserslist": "^4.16.6",
+    "dotenv": "^10.0.0",
     "eslint": "^7.30.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-config-next": "^11.0.1",

--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -12,7 +12,12 @@ type Props = {
 const Img = ({ src, alt, width, height }: Props): JSX.Element => {
   return (
     <picture>
-      <img src={src} alt={alt} width={width} height={height} />
+      <img
+        src={`${process.env.assetPrefix}${src}`}
+        alt={alt}
+        width={width}
+        height={height}
+      />
     </picture>
   );
 };


### PR DESCRIPTION
GitHub Pagesだと、URLのルートが変わって、パス指定周りがうまくいかない問題を環境変数に応じてbasepathを変えることで対応。

キトさんの作ったwebアプリを参考にした。
https://github.com/kurone-kito/dantalion/blob/master/packages/dantalion-web-playground/next.config.js#L3

Close #16 